### PR TITLE
Patch angular-oboe to handle docker's JSON streams, such as events API

### DIFF
--- a/angular-oboe.patch
+++ b/angular-oboe.patch
@@ -1,0 +1,12 @@
+diff --git "a/angular-oboe.js" "b/angular-oboe.js"
+index 49a33db..81a1077 100644
+--- "a/angular-oboe.js"
++++ "b/angular-oboe.js"
+@@ -30,6 +30,7 @@ angular.module('ngOboe', []).service('Oboe', [
+               params.done();
+             }
+             // resolve the promise
++            if (false) // workaround Docker's JSON streams
+             defer.resolve();
+             // make sure oboe cleans up memory
+             return oboe.drop;

--- a/gruntFile.js
+++ b/gruntFile.js
@@ -11,10 +11,11 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-html2js');
     grunt.loadNpmTasks('grunt-shell');
     grunt.loadNpmTasks('grunt-if');
+    grunt.loadNpmTasks('grunt-patch');
 
     // Default task.
     grunt.registerTask('default', ['jshint', 'build', 'karma:unit']);
-    grunt.registerTask('build', ['clean:app', 'if:binaryNotExist', 'html2js', 'concat', 'clean:tmpl', 'recess:build', 'copy']);
+    grunt.registerTask('build', ['clean:app', 'patch', 'if:binaryNotExist', 'html2js', 'concat', 'clean:tmpl', 'recess:build', 'copy']);
     grunt.registerTask('release', ['clean:all', 'if:binaryNotExist', 'html2js', 'uglify', 'clean:tmpl', 'jshint', 'karma:unit', 'concat:index', 'recess:min', 'copy']);
     grunt.registerTask('test-watch', ['karma:watch']);
     grunt.registerTask('run', ['if:binaryNotExist', 'build', 'shell:buildImage', 'shell:run']);
@@ -251,6 +252,16 @@ module.exports = function (grunt) {
                 },
                 ifFalse: ['shell:buildBinary']
             }
+        },
+        patch: {
+          myPatchTask: {
+            options: {
+              patch: 'angular-oboe.patch'
+            },
+            files: {
+              'bower_components/angular-oboe/dist/angular-oboe.js': 'bower_components/angular-oboe/dist/angular-oboe.js'
+            }
+          }
         }
     });
 };

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "grunt-html2js": "~0.1.0",
     "grunt-if": "^0.1.5",
     "grunt-karma": "~0.4.4",
+    "grunt-patch": "~0.1.7",
     "grunt-recess": "~0.3",
     "grunt-shell": "^1.1.2"
   },


### PR DESCRIPTION
Some docker APIs return JSON streams like below (`/events`)
```
{"status":"start","id":"54c17a09cd743b8c1ac4ff4ce3fe40fb3b703c844c07d1b17d4974d8478d245c","from":"dockerui/dockerui","time":1446223542}
{"status":"kill","id":"54c17a09cd743b8c1ac4ff4ce3fe40fb3b703c844c07d1b17d4974d8478d245c","from":"dockerui/dockerui","time":1446223545}
{"status":"die","id":"54c17a09cd743b8c1ac4ff4ce3fe40fb3b703c844c07d1b17d4974d8478d245c","from":"dockerui/dockerui","time":1446223545}
{"status":"stop","id":"54c17a09cd743b8c1ac4ff4ce3fe40fb3b703c844c07d1b17d4974d8478d245c","from":"dockerui/dockerui","time":1446223545}

```

So need to apply special patch for this.
