### PR TITLE
docker-compose example upgraded to version 2

### DIFF
--- a/examples/nginx-basic-auth/Dockerfile
+++ b/examples/nginx-basic-auth/Dockerfile
@@ -1,4 +1,3 @@
 FROM nginx:1.9.9
-
 COPY default.conf /etc/nginx/conf.d/default.conf
 COPY users.htpasswd /etc/nginx/users.htpasswd

--- a/examples/nginx-basic-auth/default.conf
+++ b/examples/nginx-basic-auth/default.conf
@@ -1,5 +1,5 @@
-upstream dockerui {
-    server dockerui:9000;
+upstream uifd {
+    server uifd:9000;
 }
 
 server {
@@ -7,11 +7,11 @@ server {
     server_name  localhost;
 
     location / {
-        auth_basic "Docker UI";
+        auth_basic "UI for Docker";
         auth_basic_user_file  /etc/nginx/users.htpasswd;
 
         proxy_http_version 1.1;
         proxy_set_header Connection "";
-        proxy_pass http://dockerui;
+        proxy_pass http://uifd;
     }
 }

--- a/examples/nginx-basic-auth/docker-compose.yml
+++ b/examples/nginx-basic-auth/docker-compose.yml
@@ -1,12 +1,15 @@
-dockerui:
-  image: dockerui/dockerui
-  privileged: true
-  volumes:
-   - /var/run/docker.sock:/var/run/docker.sock
+version: '2'
+services:
+  uifd:
+    image: uifd/ui-for-docker
+    privileged: true
+    restart: always
+    volumes:
+     - /var/run/docker.sock:/var/run/docker.sock
 
-nginx:
-  build: .
-  links:
-   - dockerui
-  ports:
-   - 80:80
+  nginx:
+    build: .
+    links:
+     - uifd
+    ports:
+     - 9999:80


### PR DESCRIPTION
Within the nginx-proxy example I've modified the docker-compose.yml in order to be compatible with the new Compose file format ver.2 and to use the right Docker image uifd/ui-for-docker.
 