### PR TITLE
Persist CSRF authkey inside a data volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,7 @@ FROM scratch
 
 COPY dist /
 
+VOLUME /data
+
 EXPOSE 9000
 ENTRYPOINT ["/ui-for-docker"]

--- a/dockerui.go
+++ b/dockerui.go
@@ -20,7 +20,7 @@ var (
 	endpoint = flag.String("e", "/var/run/docker.sock", "Dockerd endpoint")
 	addr     = flag.String("p", ":9000", "Address and port to serve UI For Docker")
 	assets   = flag.String("a", ".", "Path to the assets")
-	data		 = flag.String("d", ".", "Path to the data")
+	data     = flag.String("d", ".", "Path to the data")
 	authKey  []byte
 	authKeyFile = "authKey.dat"
 )

--- a/dockerui.go
+++ b/dockerui.go
@@ -20,6 +20,7 @@ var (
 	endpoint = flag.String("e", "/var/run/docker.sock", "Dockerd endpoint")
 	addr     = flag.String("p", ":9000", "Address and port to serve UI For Docker")
 	assets   = flag.String("a", ".", "Path to the assets")
+	data		 = flag.String("d", ".", "Path to the data")
 	authKey  []byte
 	authKeyFile = "authKey.dat"
 )
@@ -72,7 +73,7 @@ func createUnixHandler(e string) http.Handler {
 	return &UnixHandler{e}
 }
 
-func createHandler(dir string, e string) http.Handler {
+func createHandler(dir string, d string, e string) http.Handler {
 	var (
 		mux         = http.NewServeMux()
 		fileHandler = http.FileServer(http.Dir(dir))
@@ -92,11 +93,12 @@ func createHandler(dir string, e string) http.Handler {
 	}
 
 	// Use existing csrf authKey if present or generate a new one.
-	dat, err := ioutil.ReadFile(authKeyFile)
+	var authKeyPath = d + "/" + authKeyFile
+	dat, err := ioutil.ReadFile(authKeyPath)
 	if err != nil {
 		fmt.Println(err)
 		authKey = securecookie.GenerateRandomKey(32)
-		err := ioutil.WriteFile(authKeyFile, authKey, 0644)
+		err := ioutil.WriteFile(authKeyPath, authKey, 0644)
 		if err != nil {
 			fmt.Println("unable to persist auth key", err)
 		}
@@ -125,7 +127,7 @@ func csrfWrapper(h http.Handler) http.Handler {
 func main() {
 	flag.Parse()
 
-	handler := createHandler(*assets, *endpoint)
+	handler := createHandler(*assets, *data, *endpoint)
 	if err := http.ListenAndServe(*addr, handler); err != nil {
 		log.Fatal(err)
 	}

--- a/gruntFile.js
+++ b/gruntFile.js
@@ -258,14 +258,14 @@ module.exports = function (grunt) {
                 command: [
                     'docker stop ui-for-docker',
                     'docker rm ui-for-docker',
-                    'docker run --privileged -d -p 9000:9000 -v /var/run/docker.sock:/var/run/docker.sock --name ui-for-docker ui-for-docker'
+                    'docker run --privileged -d -p 9000:9000 -v /tmp/docker-ui:/data -v /var/run/docker.sock:/var/run/docker.sock --name ui-for-docker ui-for-docker -d /data'
                 ].join(';')
             },
             runSwarm: {
                 command: [
                     'docker stop ui-for-docker',
                     'docker rm ui-for-docker',
-                    'docker run --net=host -d --name ui-for-docker ui-for-docker -e http://127.0.0.1:2374'
+                    'docker run --net=host -d -v /tmp/docker-ui:/data --name ui-for-docker ui-for-docker -d /data -e http://127.0.0.1:2374'
                 ].join(';')
             },
             cleanImages: {

--- a/gruntFile.js
+++ b/gruntFile.js
@@ -258,14 +258,14 @@ module.exports = function (grunt) {
                 command: [
                     'docker stop ui-for-docker',
                     'docker rm ui-for-docker',
-                    'docker run --privileged -d -p 9000:9000 -v /tmp/docker-ui:/data -v /var/run/docker.sock:/var/run/docker.sock --name ui-for-docker ui-for-docker -d /data'
+                    'docker run --privileged -d -p 9000:9000 -v /tmp/ui-for-docker:/data -v /var/run/docker.sock:/var/run/docker.sock --name ui-for-docker ui-for-docker -d /data'
                 ].join(';')
             },
             runSwarm: {
                 command: [
                     'docker stop ui-for-docker',
                     'docker rm ui-for-docker',
-                    'docker run --net=host -d -v /tmp/docker-ui:/data --name ui-for-docker ui-for-docker -d /data -e http://127.0.0.1:2374'
+                    'docker run --net=host -d -v /tmp/ui-for-docker:/data --name ui-for-docker ui-for-docker -d /data -e http://127.0.0.1:2374'
                 ].join(';')
             },
             cleanImages: {

--- a/ui-for-docker-checksum.txt
+++ b/ui-for-docker-checksum.txt
@@ -1,0 +1,1 @@
+d9dac0d4b3d5b5a1553c35afa1b0a91949c05079  ui-for-docker

--- a/ui-for-docker-checksum.txt
+++ b/ui-for-docker-checksum.txt
@@ -1,1 +1,0 @@
-d9dac0d4b3d5b5a1553c35afa1b0a91949c05079  ui-for-docker


### PR DESCRIPTION
This fix should prevent the issue appearing in #208 

At least, it will prevent the issue from raising when using the `grunt` commands.

I'm not sure if I should add details in the README.md and if we should always run that container with a persistent volume.

@kevana thoughts?
