### PR TITLE
add the ability to pull an image from a custom registry

### DIFF
--- a/app/components/pullImage/pullImage.html
+++ b/app/components/pullImage/pullImage.html
@@ -7,19 +7,10 @@
             </div>
             <div class="modal-body">
                 <form novalidate role="form" name="pullForm">
-                    <!--<div class="input-group">
-                        <span class="input-group-addon" id="basic-addon1">Image name</span>
-                        <input type="text" class="form-control" placeholder="imageName" aria-describedby="basic-addon1">
-                    </div>-->
                     <div class="form-group">
                         <label>Registry:</label>
                         <input type="text" ng-model="config.registry" class="form-control"
                                placeholder="Registry. Leave empty to user docker hub"/>
-                    </div>
-                    <div class="form-group">
-                        <label>Repo:</label>
-                        <input type="text" ng-model="config.repo" class="form-control"
-                               placeholder="Repository - usually your username."/>
                     </div>
                     <div class="form-group">
                         <label>Image Name:</label>

--- a/app/components/pullImage/pullImageController.js
+++ b/app/components/pullImage/pullImageController.js
@@ -6,7 +6,6 @@ angular.module('pullImage', [])
             $scope.init = function () {
                 $scope.config = {
                     registry: '',
-                    repo: '',
                     fromImage: '',
                     tag: 'latest'
                 };
@@ -20,11 +19,11 @@ angular.module('pullImage', [])
 
             $scope.pull = function () {
                 $('#error-message').hide();
-                var config = angular.copy($scope.config);
-                var imageName = (config.registry ? config.registry + '/' : '' ) +
-                    (config.repo ? config.repo + '/' : '') +
-                    (config.fromImage) +
-                    (config.tag ? ':' + config.tag : '');
+                var imageName = ($scope.config.registry ? $scope.config.registry + '/' : '' ) +
+                  ($scope.config.fromImage);
+                var config = {};
+                config.fromImage = imageName;
+                config.tag = $scope.config.tag;
 
                 ViewSpinner.spin();
                 $('#pull-modal').modal('hide');

--- a/app/shared/services.js
+++ b/app/shared/services.js
@@ -89,7 +89,7 @@ angular.module('dockerui.services', ['ngResource', 'ngSanitize'])
                     var str = data.replace(/\n/g, " ").replace(/\}\W*\{/g, "}, {");
                     return angular.fromJson("[" + str + "]");
                 }],
-                params: {action: 'create', fromImage: '@fromImage', repo: '@repo', tag: '@tag', registry: '@registry'}
+                params: {action: 'create', fromImage: '@fromImage', tag: '@tag'}
             },
             insert: {method: 'POST', params: {id: '@id', action: 'insert'}},
             push: {method: 'POST', params: {id: '@id', action: 'push'}},


### PR DESCRIPTION
This PR adds the ability to pull an image from a custom registry.

It removes the `repo` field from the pull image popup, as this field should only be used when importing an image.

It also removes the `repo` and `registry` parameters from the Image API `create` endpoint as the `registry` parameter does not exist in the API and the `repo` parameter is useless in this situation, see: https://docs.docker.com/engine/reference/api/docker_remote_api_v1.23/#/create-an-image 

Close #213 