### PR TITLE
add the ability to connect to a TLS protected Docker engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ UI For Docker is a web interface for the Docker Remote API.  The goal is to prov
 * Minimal dependencies - I really want to keep this project a pure html/js app.
 * Consistency - The web UI should be consistent with the commands found on the docker CLI.
 
-### Quickstart 
+### Quickstart
 1. Run: `docker run -d -p 9000:9000 --privileged -v /var/run/docker.sock:/var/run/docker.sock uifd/ui-for-docker`
 
 2. Open your browser to `http://<dockerd host ip>:9000`
@@ -35,6 +35,19 @@ UI For Docker listens on port 9000 by default. If you run UI For Docker inside a
 
     # Expose UI For Docker on 10.20.30.1:80
     $ docker run -d -p 10.20.30.1:80:9000 --privileged -v /var/run/docker.sock:/var/run/docker.sock uifd/ui-for-docker
+
+### Access a Docker engine protected via TLS
+
+Ensure that you have access to the CA, the cert and the public key used to access your Docker engine.  
+
+These files will need to be named `ca.pem`, `cert.pem` and `key.pem` respectively. Store them somewhere on your disk and mount a volume containing these files inside the UI container:
+
+```
+# Note the access to the endpoint via https
+$ docker run -d -p 9000:9000 cloudinovasi/cloudinovasi-ui -v /path/to/certs:/certs -e https://my-docker-host.domain:2376
+```
+
+*Note*: Replace `/path/to/certs` to the path to the certificate files on your disk.
 
 ### Check the [wiki](https://github.com/kevana/ui-for-docker/wiki) for more info about using UI For Docker
 
@@ -62,24 +75,24 @@ The UI For Docker code is licensed under the MIT license.
 Copyright (c) 2013-2016 Michael Crosby (crosbymichael.com), Kevan Ahlquist (kevanahlquist.com)
 
 Permission is hereby granted, free of charge, to any person
-obtaining a copy of this software and associated documentation 
-files (the "Software"), to deal in the Software without 
-restriction, including without limitation the rights to use, copy, 
-modify, merge, publish, distribute, sublicense, and/or sell copies 
-of the Software, and to permit persons to whom the Software is 
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use, copy,
+modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be 
+The above copyright notice and this permission notice shall be
 included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 EXPRESS OR IMPLIED,
-INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT 
-HOLDERS BE LIABLE FOR ANY CLAIM, 
-DAMAGES OR OTHER LIABILITY, 
-WHETHER IN AN ACTION OF CONTRACT, 
-TORT OR OTHERWISE, 
-ARISING FROM, OUT OF OR IN CONNECTION WITH 
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH
 THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ These files will need to be named `ca.pem`, `cert.pem` and `key.pem` respectivel
 
 ```
 # Note the access to the endpoint via https
-$ docker run -d -p 9000:9000 cloudinovasi/cloudinovasi-ui -v /path/to/certs:/certs -e https://my-docker-host.domain:2376
+$ docker run -d -p 9000:9000 uifd/ui-for-docker -v /path/to/certs:/certs -e https://my-docker-host.domain:2376
 ```
 
 *Note*: Replace `/path/to/certs` to the path to the certificate files on your disk.

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ Bind mounting the Unix socket into the UI For Docker container is much more secu
 
 By default UI For Docker connects to the Docker daemon with`/var/run/docker.sock`. For this to work you need to bind mount the unix socket into the container with `-v /var/run/docker.sock:/var/run/docker.sock`.
 
-You can use the `-e` flag to change this socket:
+You can use the `-H` flag to change this socket:
 
     # Connect to a tcp socket:
-    $ docker run -d -p 9000:9000 --privileged uifd/ui-for-docker -e http://127.0.0.1:2375
+    $ docker run -d -p 9000:9000 --privileged uifd/ui-for-docker -H tcp://127.0.0.1:2375
 
 ### Change address/port UI For Docker is served on
 UI For Docker listens on port 9000 by default. If you run UI For Docker inside a container then you can bind the container's internal port to any external address and port:
@@ -38,13 +38,18 @@ UI For Docker listens on port 9000 by default. If you run UI For Docker inside a
 
 ### Access a Docker engine protected via TLS
 
-Ensure that you have access to the CA, the cert and the public key used to access your Docker engine.  
+Ensure that you have access to the CA, the TLS certificate and the TLS key used to access your Docker engine.  
 
 These files will need to be named `ca.pem`, `cert.pem` and `key.pem` respectively. Store them somewhere on your disk and mount a volume containing these files inside the UI container:
 
 ```
-# Note the access to the endpoint via https
-$ docker run -d -p 9000:9000 uifd/ui-for-docker -v /path/to/certs:/certs -e https://my-docker-host.domain:2376
+$ docker run -d -p 9000:9000 uifd/ui-for-docker -v /path/to/certs:/certs -H tcp://my-docker-host.domain:2376 -tlsverify
+```
+
+If you want to specify different names for the CA, certificate and public key respectively you can use the `-tlscacert`, `-tlscert` and `-tlskey`:
+
+```
+$ docker run -d -p 9000:9000 uifd/ui-for-docker -v /path/to/certs:/certs -H tcp://my-docker-host.domain:2376 -tlsverify -tlscacert /certs/myCA.pem -tlscert /certs/myCert.pem -tlskey /certs/myKey.pem
 ```
 
 *Note*: Replace `/path/to/certs` to the path to the certificate files on your disk.

--- a/dockerui.go
+++ b/dockerui.go
@@ -9,7 +9,6 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
-	"strings"
 	"github.com/gorilla/csrf"
 	"io/ioutil"
 	"fmt"
@@ -19,17 +18,27 @@ import (
 )
 
 var (
-	endpoint = flag.String("e", "/var/run/docker.sock", "Dockerd endpoint")
-	addr     = flag.String("p", ":9000", "Address and port to serve UI For Docker")
-	assets   = flag.String("a", ".", "Path to the assets")
-	data     = flag.String("d", ".", "Path to the data")
-	certs    = flag.String("c", "/certs", "Path to the certs")
+	endpoint 	= flag.String("H", "unix:///var/run/docker.sock", "Dockerd endpoint")
+	addr     	= flag.String("p", ":9000", "Address and port to serve UI For Docker")
+	assets   	= flag.String("a", ".", "Path to the assets")
+	data     	= flag.String("d", ".", "Path to the data")
+	tlsverify = flag.Bool("tlsverify", false, "TLS support")
+	tlscacert = flag.String("tlscacert", "/certs/ca.pem", "Path to the CA")
+	tlscert   = flag.String("tlscert", "/certs/cert.pem", "Path to the TLS certificate file")
+	tlskey    = flag.String("tlskey", "/certs/key.pem", "Path to the TLS key")
 	authKey  []byte
 	authKeyFile = "authKey.dat"
 )
 
 type UnixHandler struct {
 	path string
+}
+
+type TLSFlags struct {
+	tls bool
+	caPath string
+	certPath string
+	keyPath string
 }
 
 func (h *UnixHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -64,20 +73,12 @@ func copyHeader(dst, src http.Header) {
 	}
 }
 
-func createTcpHandler(e string) http.Handler {
-	u, err := url.Parse(e)
+func createTLSConfig(flags TLSFlags) *tls.Config {
+	cert, err := tls.LoadX509KeyPair(flags.certPath, flags.keyPath)
 	if err != nil {
 		log.Fatal(err)
 	}
-	return httputil.NewSingleHostReverseProxy(u)
-}
-
-func createTlsConfig(c string) *tls.Config {
-	cert, err := tls.LoadX509KeyPair(c + "/" + "cert.pem", c + "/" + "key.pem")
-	if err != nil {
-		log.Fatal(err)
-	}
-	caCert, err := ioutil.ReadFile(c + "/" + "ca.pem")
+	caCert, err := ioutil.ReadFile(flags.caPath)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -90,12 +91,14 @@ func createTlsConfig(c string) *tls.Config {
 	return tlsConfig;
 }
 
-func createTcpHandlerWithTLS(e string, c string) http.Handler {
-	u, err := url.Parse(e)
-	if err != nil {
-		log.Fatal(err)
-	}
-	var tlsConfig = createTlsConfig(c)
+func createTcpHandler(u *url.URL) http.Handler {
+	u.Scheme = "http";
+	return httputil.NewSingleHostReverseProxy(u)
+}
+
+func createTcpHandlerWithTLS(u *url.URL, flags TLSFlags) http.Handler {
+	u.Scheme = "https";
+	var tlsConfig = createTLSConfig(flags)
 	proxy := httputil.NewSingleHostReverseProxy(u)
 	proxy.Transport = &http.Transport{
 		TLSClientConfig: tlsConfig,
@@ -107,25 +110,35 @@ func createUnixHandler(e string) http.Handler {
 	return &UnixHandler{e}
 }
 
-func createHandler(dir string, d string, c string, e string) http.Handler {
+func createHandler(dir string, d string, e string, flags TLSFlags) http.Handler {
 	var (
 		mux         = http.NewServeMux()
 		fileHandler = http.FileServer(http.Dir(dir))
 		h           http.Handler
 	)
 
-	if strings.Contains(e, "https") {
-		h = createTcpHandlerWithTLS(e, c)
-	} else if strings.Contains(e, "http") {
-		h = createTcpHandler(e)
-	} else {
-		if _, err := os.Stat(e); err != nil {
+	u, perr := url.Parse(e)
+	if perr != nil {
+		log.Fatal(perr)
+	}
+
+	if u.Scheme == "tcp" {
+		if flags.tls {
+			h = createTcpHandlerWithTLS(u, flags)
+		} else {
+			h = createTcpHandler(u)
+		}
+	} else if u.Scheme == "unix" {
+		var socketPath = u.Path
+		if _, err := os.Stat(socketPath); err != nil {
 			if os.IsNotExist(err) {
-				log.Fatalf("unix socket %s does not exist", e)
+				log.Fatalf("unix socket %s does not exist", socketPath)
 			}
 			log.Fatal(err)
 		}
-		h = createUnixHandler(e)
+		h = createUnixHandler(socketPath)
+	} else {
+		log.Fatalf("Bad Docker enpoint: %s. Only unix:// and tcp:// are supported.", e)
 	}
 
 	// Use existing csrf authKey if present or generate a new one.
@@ -163,7 +176,14 @@ func csrfWrapper(h http.Handler) http.Handler {
 func main() {
 	flag.Parse()
 
-	handler := createHandler(*assets, *data, *certs, *endpoint)
+	tlsFlags := TLSFlags{
+		tls: *tlsverify,
+		caPath: *tlscacert,
+		certPath: *tlscert,
+		keyPath: *tlskey,
+	}
+
+	handler := createHandler(*assets, *data, *endpoint, tlsFlags)
 	if err := http.ListenAndServe(*addr, handler); err != nil {
 		log.Fatal(err)
 	}

--- a/gruntFile.js
+++ b/gruntFile.js
@@ -265,7 +265,7 @@ module.exports = function (grunt) {
                 command: [
                     'docker stop ui-for-docker',
                     'docker rm ui-for-docker',
-                    'docker run --net=host -d -v /tmp/ui-for-docker:/data --name ui-for-docker ui-for-docker -d /data -e http://127.0.0.1:2374'
+                    'docker run --net=host -d -v /tmp/ui-for-docker:/data --name ui-for-docker ui-for-docker -d /data -H tcp://127.0.0.1:2374'
                 ].join(';')
             },
             cleanImages: {


### PR DESCRIPTION
This PR adds the ability to connect to a Docker engine protected via TLS.

It requires the user to have the `ca.pem`, `cert.pem` and `key.pem` certificate files used to authenticate against a TLS protected Docker engine, see: https://docs.docker.com/engine/security/https/

These files are usually used the following way with the Docker CLI:
```
$ docker --tlsverify --tlscacert=ca.pem --tlscert=cert.pem --tlskey=key.pem -H=$HOST:2376 info
```

These files can now be mounted inside the UIFD container to establish a secure connection to a Docker engine. They must be named `ca.pem`, `cert.pem` and `key.pem` respectively and available on the host where the UIFD container will be running.

For example, if I stored the files inside the `/etc/ssl/uifd` folder, then I can run the following UIFD container:

```
# Use HTTPS to access your Docker endpoint
$ docker run -d -p 9000:9000 -v /etc/ssl/uifd:/certs uifd/ui-for-docker -e https://mydockerhost.domain:2376
```

Note: the secure connection between UIFD and the Docker engine will be enabled only when the `https` scheme is used in the endpoint declaration, see: https://github.com/kevana/ui-for-docker/pull/230/commits/68959dd5a1aaae16b8b9310763c516d64eaddc96#diff-e6eae2402cb162870dbd115fe331f76bR117