### PR TITLE
Remove the HostConfig parameter from the Container.start request

### DIFF
--- a/app/components/containers/containersController.js
+++ b/app/components/containers/containersController.js
@@ -37,7 +37,7 @@ angular.module('containers', [])
                             Container.get({id: c.Id}, function (d) {
                                 c = d;
                                 counter = counter + 1;
-                                action({id: c.Id, HostConfig: c.HostConfig || {}}, function (d) {
+                                action({id: c.Id}, {}, function (d) {
                                     Messages.send("Container " + msg, c.Id);
                                     var index = $scope.containers.indexOf(c);
                                     complete();

--- a/app/components/startContainer/startContainerController.js
+++ b/app/components/startContainer/startContainerController.js
@@ -125,19 +125,10 @@ angular.module('startContainer', ['ui.bootstrap'])
                 var s = $scope;
                 Container.create(config, function (d) {
                     if (d.Id) {
-                        var reqBody = config.HostConfig || {};
-                        reqBody.id = d.Id;
-                        ctor.start(reqBody, function (cd) {
-                            if (cd.id) {
-                                Messages.send('Container Started', d.Id);
-                                $('#create-modal').modal('hide');
-                                loc.path('/containers/' + d.Id + '/');
-                            } else {
-                                failedRequestHandler(cd, Messages);
-                                ctor.remove({id: d.Id}, function () {
-                                    Messages.send('Container Removed', d.Id);
-                                });
-                            }
+                        ctor.start({id: d.Id}, {}, function (cd) {
+                            Messages.send('Container Started', d.Id);
+                            $('#create-modal').modal('hide');
+                            loc.path('/containers/' + d.Id + '/');
                         }, function (e) {
                             failedRequestHandler(e, Messages);
                         });


### PR DESCRIPTION
Fix #234 

This PR removes the HostConfig parameter when trying to start a container. This allows the UI to start containers on Docker 1.12.

I've tested, it's supported from 1.9 to 1.12. Did not test with Docker < 1.9 though.

It also removes some logic part in the `startContainerController.js` which was checking for an ID in the response after starting a container otherwise it would remove the container assuming the start request failed.

As we can see in the API documentation here: https://docs.docker.com/engine/reference/api/docker_remote_api_v1.24/#/start-a-container the API returns an empty response after a start request.
